### PR TITLE
Use env for Notion config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+NOTION_API_KEY=your-notion-api-key
+NOTION_DATABASE_ID=your-database-id

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Environment variables
+.env
+

--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,7 @@ Questo repository contiene un esempio di sito web per una tribute band.
 
 1. Crea un database in Notion con i campi `Name`, `Data` (di tipo *date*) e `Location` (testo). Utilizza la vista *Calendar* per gestire gli eventi.
 2. Ottieni un token di integrazione da Notion e condividi il database con l'integrazione.
-3. Nel file `server.js` sono già impostati un esempio di token e di ID del database: sostituiscili se necessario con i tuoi valori.
+3. Imposta le variabili d'ambiente `NOTION_API_KEY` e `NOTION_DATABASE_ID` con i valori del tuo account Notion. Puoi creare un file `.env` (vedi `.env.example`) per caricarle automaticamente in locale tramite [dotenv](https://github.com/motdotla/dotenv).
 4. Avvia il server con `node server.js` e visita `http://localhost:3000` in un browser per visualizzare il sito.
 
 

--- a/server.js
+++ b/server.js
@@ -2,8 +2,15 @@ const http = require('http');
 const fs = require('fs');
 const path = require('path');
 
-const notionApiKey = '5fe69fd43f1740b0b2e94b9b61a863a4';
-const databaseId = '3c372175215e43ec95ce3c35feee1b31';
+// Load environment variables from a .env file when available
+try {
+  require('dotenv').config();
+} catch (err) {
+  // dotenv is optional; ignore if not installed
+}
+
+const notionApiKey = process.env.NOTION_API_KEY;
+const databaseId = process.env.NOTION_DATABASE_ID;
 
 const port = 3000;
 


### PR DESCRIPTION
## Summary
- read Notion credentials from environment variables
- support optional `.env` file
- provide example `.env` file and ignore real one
- update configuration steps in the documentation

## Testing
- `npm test` *(fails: could not find package.json)*
- `node server.js` *(starts server then stops)*

------
https://chatgpt.com/codex/tasks/task_e_68639834253c8322ad48bede9aac854d