### PR TITLE
Fetch concerts directly from Notion

### DIFF
--- a/events.json
+++ b/events.json
@@ -1,0 +1,19 @@
+{
+  "upcoming": [
+    {
+      "properties": {
+        "Name": { "title": [ { "plain_text": "Concerto di prova" } ] },
+        "Data": { "date": { "start": "2025-01-01" } }
+      }
+    }
+  ],
+  "past": [
+    {
+      "properties": {
+        "Name": { "title": [ { "plain_text": "Concerto passato" } ] },
+        "Data": { "date": { "start": "2024-01-01" } },
+        "Location": { "rich_text": [ { "plain_text": "Roma, Italia" } ] }
+      }
+    }
+  ]
+}

--- a/readme.md
+++ b/readme.md
@@ -15,6 +15,9 @@ Questo repository contiene un esempio di sito web per una tribute band.
 2. Ottieni un token di integrazione da Notion e condividi il database con l'integrazione.
 3. Imposta le variabili d'ambiente `NOTION_API_KEY` e `NOTION_DATABASE_ID` con i valori del tuo account Notion. Puoi creare un file `.env` (vedi `.env.example`) per caricarle automaticamente in locale tramite [dotenv](https://github.com/motdotla/dotenv).
 4. Avvia il server con `node server.js` e visita `http://localhost:3000` in un browser per visualizzare il sito.
+   In ambienti statici (ad esempio GitHub Pages) non è disponibile l'endpoint
+   `/events`; per mostrare un elenco dimostrativo puoi fornire un file
+   `events.json` come quello presente in questo repository.
 
 Assicurati di usare **Node.js 18 o superiore**, necessario per l'API `fetch` integrata. Se riscontri errori di `fetch`, installa il pacchetto `node-fetch` oppure aggiorna la tua versione di Node.
 

--- a/script.js
+++ b/script.js
@@ -1,7 +1,38 @@
 
+const NOTION_API_KEY = '5fe69fd43f1740b0b2e94b9b61a863a4';
+const NOTION_DATABASE_ID = '3c372175215e43ec95ce3c35feee1b31';
+const NOTION_VERSION = '2022-06-28';
+
 async function fetchEvents() {
-  const res = await fetch('/events');
-  const data = await res.json();
+  const url = `https://api.notion.com/v1/databases/${NOTION_DATABASE_ID}/query`;
+  const headers = {
+    'Authorization': `Bearer ${NOTION_API_KEY}`,
+    'Notion-Version': NOTION_VERSION,
+    'Content-Type': 'application/json'
+  };
+  const today = new Date().toISOString().split('T')[0];
+  const body = {
+    page_size: 100,
+    filter: { property: 'Data', date: { after: today } },
+    sorts: [{ property: 'Data', direction: 'ascending' }]
+  };
+
+  let data;
+  try {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(body)
+    });
+    if (!res.ok) throw new Error('Notion API error');
+    const notionData = await res.json();
+    data = { upcoming: notionData.results, past: [] };
+  } catch (err) {
+    // On static hosting or if the Notion request fails,
+    // fall back to a bundled JSON file with sample data.
+    const res = await fetch('events.json');
+    data = await res.json();
+  }
 
 
   const upcomingList = document.getElementById('upcoming-list');


### PR DESCRIPTION
## Summary
- fetch upcoming concerts directly from Notion
- fall back to `events.json` on failure

## Testing
- `node -c script.js`
- `node -c server.js`


------
https://chatgpt.com/codex/tasks/task_e_68639b3263b08322a5b16bc5449d02de