### PR TITLE
Fix Notion request and drop static fallback

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,42 +1,40 @@
 
 async function fetchEvents() {
-  const res = await fetch('/events');
-  const data = await res.json();
-
+  try {
+    const res = await fetch('/events');
+    if (!res.ok) {
+      console.error('Errore caricamento eventi', await res.text());
+      return;
+    }
+    const data = await res.json();
+    const events = [...data.upcoming, ...data.past];
+    const today = new Date().toISOString().split('T')[0];
 
   const upcomingList = document.getElementById('upcoming-list');
+  upcomingList.innerHTML = '';
   const pastList = document.getElementById('past-list');
+  pastList.innerHTML = '';
 
-
-  data.upcoming.forEach(page => {
-
-
-    const name = page.properties.Name.title[0].plain_text;
-    const dateProp = page.properties.Data;
-    if (dateProp && dateProp.date) {
+    events.forEach(page => {
+      const name = page.properties.Name.title[0].plain_text;
+      const dateProp = page.properties.Data;
+      const locationProp = page.properties.Location;
+      if (!dateProp || !dateProp.date) return;
       const date = new Date(dateProp.date.start);
       const item = document.createElement('li');
       item.textContent = `${name} - ${date.toLocaleDateString()}`;
-      upcomingList.appendChild(item);
-    }
-  });
-
-
-  data.past.forEach(page => {
-
-    const name = page.properties.Name.title[0].plain_text;
-    const dateProp = page.properties.Data;
-    const locationProp = page.properties.Location;
-    if (dateProp && dateProp.date) {
-      const date = new Date(dateProp.date.start);
-      const item = document.createElement('li');
-      item.textContent = `${name} - ${date.toLocaleDateString()}`;
-      pastList.appendChild(item);
-      if (locationProp && locationProp.rich_text.length > 0) {
-        addMarker(locationProp.rich_text[0].plain_text);
+      if (date >= new Date(today)) {
+        upcomingList.appendChild(item);
+      } else {
+        pastList.appendChild(item);
+        if (locationProp && locationProp.rich_text.length > 0) {
+          addMarker(locationProp.rich_text[0].plain_text);
+        }
       }
-    }
-  });
+    });
+  } catch (err) {
+    console.error('Impossibile recuperare gli eventi', err);
+  }
 }
 
 // Mappa con Leaflet


### PR DESCRIPTION
## Summary
- fetch events through `/events` server endpoint again
- handle errors gracefully in the client script

## Testing
- `node -c script.js`
- `node -c server.js`


------
https://chatgpt.com/codex/tasks/task_e_68639b3263b08322a5b16bc5449d02de