### PR TITLE
Remove Notion API from Node server

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,0 @@
-NOTION_API_KEY=your-notion-api-key
-NOTION_DATABASE_ID=your-database-id

--- a/readme.md
+++ b/readme.md
@@ -5,19 +5,15 @@ Questo repository contiene un esempio di sito web per una tribute band.
 ## Contenuto del sito
 
 - **Bio**: una sezione dove inserire una breve biografia della band.
-- **Prossimi concerti**: eventi caricati da un calendario su Notion tramite le API.
+- **Prossimi concerti**: eventi caricati da un file `events.json`.
 - **Concerti passati**: elenco delle date già eseguite.
 - **Mappa**: posizione dei luoghi in cui la band ha suonato, visualizzati tramite Leaflet.
 
 ## Configurazione
 
-1. Crea un database in Notion con i campi `Name`, `Data` (di tipo *date*) e `Location` (testo). Utilizza la vista *Calendar* per gestire gli eventi.
-2. Ottieni un token di integrazione da Notion e condividi il database con l'integrazione.
-3. Imposta le variabili d'ambiente `NOTION_API_KEY` e `NOTION_DATABASE_ID` con i valori del tuo account Notion. Puoi creare un file `.env` (vedi `.env.example`) per caricarle automaticamente in locale tramite [dotenv](https://github.com/motdotla/dotenv).
-4. Avvia il server con `node server.js` e visita `http://localhost:3000` in un browser per visualizzare il sito.
-   In ambienti statici (ad esempio GitHub Pages) non è disponibile l'endpoint
-   `/events`; per mostrare un elenco dimostrativo puoi fornire un file
-   `events.json` come quello presente in questo repository.
+1. Clona il repository in locale.
+2. Avvia il server con `node server.js` e visita `http://localhost:3000` in un browser per visualizzare il sito.
+   Gli eventi vengono letti dal file `events.json` presente nella radice del progetto.
 
 Assicurati di usare **Node.js 18 o superiore**, necessario per l'API `fetch` integrata. Se riscontri errori di `fetch`, installa il pacchetto `node-fetch` oppure aggiorna la tua versione di Node.
 

--- a/script.js
+++ b/script.js
@@ -1,24 +1,14 @@
-
 async function fetchEvents() {
   try {
-    const res = await fetch('/events');
-
-    const text = await res.text();
-    if (!res.ok) {
-      displayApiOutput(text);
-      return;
-    }
-    const data = JSON.parse(text);
+    const res = await fetch('events.json');
+    const data = await res.json();
     populateLists(data.upcoming, data.past);
   } catch (err) {
-    displayApiOutput(String(err));
-
     console.error('Failed to load events', err);
   }
 }
 
 function populateLists(upcoming = [], past = []) {
-
   const upcomingList = document.getElementById('upcoming-list');
   const pastList = document.getElementById('past-list');
   upcomingList.innerHTML = '';
@@ -32,8 +22,8 @@ function populateLists(upcoming = [], past = []) {
       const item = document.createElement('li');
       item.textContent = `${name} - ${date.toLocaleDateString()}`;
       upcomingList.appendChild(item);
-
-
+    }
+  });
 
   past.forEach(page => {
     const name = page.properties.Name.title[0].plain_text;
@@ -44,37 +34,11 @@ function populateLists(upcoming = [], past = []) {
       const item = document.createElement('li');
       item.textContent = `${name} - ${date.toLocaleDateString()}`;
       pastList.appendChild(item);
-      if (locationProp && locationProp.rich_text.length > 0) {
+      if (locationProp && locationProp.rich_text && locationProp.rich_text.length > 0) {
         addMarker(locationProp.rich_text[0].plain_text);
-
       }
-    });
-
-    pastData.results.forEach(page => {
-      const name = page.properties.Name.title[0].plain_text;
-      const dateProp = page.properties.Data;
-      const locationProp = page.properties.Location;
-      if (dateProp && dateProp.date) {
-        const date = new Date(dateProp.date.start);
-        const item = document.createElement('li');
-        item.textContent = `${name} - ${date.toLocaleDateString()}`;
-        pastList.appendChild(item);
-        if (locationProp && locationProp.rich_text.length > 0) {
-          addMarker(locationProp.rich_text[0].plain_text);
-        }
-      }
-    });
-
-  } catch (err) {
-    console.error('Impossibile recuperare gli eventi', err);
-  }
-}
-
-function displayApiOutput(raw) {
-  const upcomingList = document.getElementById('upcoming-list');
-  const pastList = document.getElementById('past-list');
-  upcomingList.innerHTML = `<pre>${raw}</pre>`;
-  pastList.innerHTML = '';
+    }
+  });
 }
 
 // Mappa con Leaflet

--- a/server.js
+++ b/server.js
@@ -9,14 +9,6 @@ try {
   // dotenv is optional; ignore if not installed
 }
 
-// Notion credentials. Can be overridden by environment variables
-const notionApiKey =
-  process.env.NOTION_API_KEY ||
-  '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';
-const databaseId =
-  process.env.NOTION_DATABASE_ID ||
-  '5fe69fd43f1740b0b2e94b9b61a863a4';
-
 const port = 3000;
 
 const mimeTypes = {
@@ -26,38 +18,6 @@ const mimeTypes = {
   '.json': 'application/json'
 };
 
-async function handleEvents(res) {
-  const url = `https://api.notion.com/v1/databases/${databaseId}/query`;
-  const headers = {
-    'Authorization': `Bearer ${notionApiKey}`,
-    'Notion-Version': '2022-06-28',
-    'Content-Type': 'application/json'
-  };
-  const today = new Date().toISOString().split('T')[0];
-  const query = {
-    filter: { property: 'Data', date: { on_or_after: today } },
-    sorts: [{ property: 'Data', direction: 'ascending' }]
-  };
-  try {
-    const notionRes = await fetch(url, {
-      method: 'POST',
-      headers,
-      body: JSON.stringify(query)
-    });
-    const output = await notionRes.json();
-    if (!notionRes.ok) {
-      res.writeHead(notionRes.status, { 'Content-Type': 'application/json' });
-      res.end(JSON.stringify(output));
-      return;
-    }
-    res.writeHead(200, { 'Content-Type': 'application/json' });
-    res.end(JSON.stringify({ upcoming: output.results }));
-  } catch (err) {
-    console.error(err);
-    res.writeHead(500, { 'Content-Type': 'application/json' });
-    res.end(JSON.stringify({ error: err.message }));
-  }
-}
 
 const WEB_ROOT = path.resolve(__dirname);
 const allowedFiles = {
@@ -102,11 +62,7 @@ function serveStatic(req, res) {
 }
 
 const server = http.createServer((req, res) => {
-  if (req.url === '/events') {
-    handleEvents(res);
-  } else {
-    serveStatic(req, res);
-  }
+  serveStatic(req, res);
 });
 
 server.listen(port, () => {


### PR DESCRIPTION
## Summary
- drop Node.js code that queried Notion
- simplify `script.js` to read from local `events.json`
- clean up documentation and delete unused env example

## Testing
- `node --check server.js`
- `python -m py_compile scripts/export_notion.py`


------
https://chatgpt.com/codex/tasks/task_e_68658ca1b4e4832293058ca368f6167b