### PR TITLE
Display upcoming concerts from Notion

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,5 +33,6 @@
 
   <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
   <script src="script.js"></script>
+  <script src="notion-upcoming.js"></script>
 </body>
 </html>

--- a/notion-upcoming.js
+++ b/notion-upcoming.js
@@ -1,0 +1,37 @@
+// notion-upcoming.js
+// Load upcoming concerts from public/notion.json and display place and date
+
+async function loadUpcomingFromNotion() {
+  try {
+    const res = await fetch('public/notion.json');
+    const pages = await res.json();
+
+    const upcomingList = document.getElementById('upcoming-list');
+    upcomingList.innerHTML = '';
+
+    const now = new Date();
+
+    const events = pages
+      .map(page => {
+        const dateProp = page.properties?.Data;
+        const placeProp = page.properties?.Luogo;
+        if (!dateProp?.date || !placeProp?.rich_text?.length) return null;
+        return {
+          date: new Date(dateProp.date.start),
+          place: placeProp.rich_text[0].plain_text
+        };
+      })
+      .filter(e => e && e.date >= now)
+      .sort((a, b) => a.date - b.date);
+
+    events.forEach(ev => {
+      const item = document.createElement('li');
+      item.textContent = `${ev.place} - ${ev.date.toLocaleDateString()}`;
+      upcomingList.appendChild(item);
+    });
+  } catch (err) {
+    console.error('Failed to load Notion concerts', err);
+  }
+}
+
+document.addEventListener('DOMContentLoaded', loadUpcomingFromNotion);


### PR DESCRIPTION
## Summary
- load events from `public/notion.json`
- populate `Prossimi Concerti` list with location and date

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68662d61cb8483229f27a4a36f2c9a54