### PR TITLE
Display upcoming concerts from Notion

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,5 +33,6 @@
 
   <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
   <script src="script.js"></script>
+  <script src="notion-upcoming.js"></script>
 </body>
 </html>

--- a/notion-upcoming.js
+++ b/notion-upcoming.js
@@ -1,0 +1,42 @@
+// notion-upcoming.js
+// Load upcoming concerts from public/notion.json and display date, venue and location
+
+async function loadUpcomingFromNotion() {
+  try {
+    const res = await fetch('public/notion.json');
+    const pages = await res.json();
+
+    const upcomingList = document.getElementById('upcoming-list');
+    upcomingList.innerHTML = '';
+
+    const now = new Date();
+
+    const events = pages
+      .map(page => {
+        const dateProp = page.properties?.Data;
+        const locationProp = page.properties?.Luogo;
+        const venueProp = page.properties?.Locale;
+        if (!dateProp?.date ||
+            !locationProp?.rich_text?.length ||
+            !venueProp?.title?.length) return null;
+        return {
+          date: new Date(dateProp.date.start),
+          venue: venueProp.title[0].plain_text,
+          location: locationProp.rich_text[0].plain_text
+        };
+      })
+      .filter(e => e && e.date >= now)
+      .sort((a, b) => a.date - b.date);
+
+    events.forEach(ev => {
+      const item = document.createElement('li');
+      const dateStr = ev.date.toLocaleDateString();
+      item.textContent = `${dateStr} - ${ev.venue}, ${ev.location}`;
+      upcomingList.appendChild(item);
+    });
+  } catch (err) {
+    console.error('Failed to load Notion concerts', err);
+  }
+}
+
+document.addEventListener('DOMContentLoaded', loadUpcomingFromNotion);


### PR DESCRIPTION
## Summary
- load events from `public/notion.json`
- show date, venue, and location in `Prossimi Concerti`

## Testing
- `node --version`
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68662d61cb8483229f27a4a36f2c9a54