### PR TITLE
Add past concerts and schedule daily Notion export

### DIFF
--- a/.github/workflows/downloadPastFromNotion.yml
+++ b/.github/workflows/downloadPastFromNotion.yml
@@ -1,0 +1,24 @@
+name: Export past concerts from Notion
+on:
+  schedule:
+    - cron: '0 1 * * *'
+  workflow_dispatch:
+jobs:
+  export:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - run: pip install notion-client
+      - run: python scripts/export_past.py
+        env:
+          NOTION_TOKEN: ${{ secrets.NOTION_TOKEN }}
+          DATABASE_ID: ${{ secrets.DATABASE_ID }}
+      - run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add public/past-notion.json
+          git diff --staged --quiet || git commit -m "chore: update past concerts"
+          git push

--- a/index.html
+++ b/index.html
@@ -34,5 +34,8 @@
   <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
   <script src="script.js"></script>
   <script src="notion-upcoming.js"></script>
+
+  <script src="notion-past.js"></script>
+
 </body>
 </html>

--- a/notion-past.js
+++ b/notion-past.js
@@ -1,0 +1,35 @@
+// notion-past.js
+// Load past concerts from public/past-notion.json, list them and add markers
+
+async function loadPastFromNotion() {
+  try {
+    const res = await fetch('public/past-notion.json');
+    const pages = await res.json();
+
+    const pastList = document.getElementById('past-list');
+    pastList.innerHTML = '';
+
+    const now = new Date();
+
+    pages.forEach(page => {
+      const props = page.properties || {};
+      const dateProp = props.Data;
+      const nameProp = props.Name;
+      const locationProp = props.Location || props.Luogo;
+      if (!dateProp || !dateProp.date || !dateProp.date.start) return;
+      const date = new Date(dateProp.date.start);
+      if (date >= now) return;
+      const name = nameProp?.title?.[0]?.plain_text || '';
+      const item = document.createElement('li');
+      item.textContent = `${name} - ${date.toLocaleDateString()}`;
+      pastList.appendChild(item);
+      if (locationProp?.rich_text?.length) {
+        addMarker(locationProp.rich_text[0].plain_text);
+      }
+    });
+  } catch (err) {
+    console.error('Failed to load past concerts from Notion', err);
+  }
+}
+
+document.addEventListener('DOMContentLoaded', loadPastFromNotion);

--- a/notion-upcoming.js
+++ b/notion-upcoming.js
@@ -38,6 +38,11 @@ async function loadUpcomingFromNotion() {
       const dateStr = ev.date.toLocaleDateString();
       item.textContent = `${dateStr} - ${ev.venue}, ${ev.location}`;
 
+
+      const dateStr = ev.date.toLocaleDateString();
+      item.textContent = `${dateStr} - ${ev.venue}, ${ev.location}`;
+
+
       upcomingList.appendChild(item);
     });
   } catch (err) {

--- a/scripts/export_past.py
+++ b/scripts/export_past.py
@@ -1,0 +1,51 @@
+import os
+import json
+import pathlib
+import datetime
+from notion_client import Client
+
+NOTION_TOKEN = os.environ["NOTION_TOKEN"]
+DATABASE_ID = os.environ["DATABASE_ID"]
+
+client = Client(auth=NOTION_TOKEN)
+
+def fetch_all_pages(db_id):
+    cursor = None
+    while True:
+        resp = client.databases.query(database_id=db_id, start_cursor=cursor, page_size=100)
+        yield from resp["results"]
+        if not resp["has_more"]:
+            break
+        cursor = resp["next_cursor"]
+
+def main():
+    today = datetime.date.today()
+    pages = list(fetch_all_pages(DATABASE_ID))
+    past = []
+    for page in pages:
+        date_prop = page.get("properties", {}).get("Data")
+        date_info = date_prop.get("date") if date_prop else None
+        if not date_info:
+            continue
+        date_str = date_info.get("start")
+        if not date_str:
+            continue
+        try:
+            date_value = datetime.date.fromisoformat(date_str)
+        except ValueError:
+            continue
+        if date_value < today:
+            past.append(page)
+
+    out_dir = pathlib.Path("public")
+    out_dir.mkdir(exist_ok=True)
+    out_file = out_dir / "past-notion.json"
+    out_file.write_text(json.dumps(past, ensure_ascii=False, indent=2), encoding="utf-8")
+    try:
+        display_path = out_file.resolve().relative_to(pathlib.Path.cwd())
+    except ValueError:
+        display_path = out_file
+    print(f"\u2714 Exported {display_path}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- export past concerts from Notion with `export_past.py`
- run new GitHub Action every day to update `public/past-notion.json`
- display past concerts on the map and in the list

## Testing
- `node --version`
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68662d61cb8483229f27a4a36f2c9a54