### PR TITLE
Update export_past to parse datetimes

### DIFF
--- a/scripts/export_past.py
+++ b/scripts/export_past.py
@@ -31,9 +31,15 @@ def main():
         if not date_str:
             continue
         try:
-            date_value = datetime.date.fromisoformat(date_str)
+            date_value = (
+                datetime.datetime.fromisoformat(date_str.replace("Z", "+00:00"))
+                .date()
+            )
         except ValueError:
-            continue
+            try:
+                date_value = datetime.date.fromisoformat(date_str)
+            except ValueError:
+                continue
         if date_value < today:
             past.append(page)
 


### PR DESCRIPTION
## Summary
- allow parsing of date strings that include times when exporting past events

## Testing
- `python -m py_compile scripts/export_past.py`


------
https://chatgpt.com/codex/tasks/task_e_68663ea79b2c8322b0ce7906c0101219